### PR TITLE
Remove spurious while loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,10 +13,6 @@ ap = network.WLAN(network.AP_IF)
 ap.config(essid=ssid, password=password)
 ap.active(True)
 
-# Wait until it is active
-while ap.active == False:
-    pass
-
 print("Access point active")
 # Print out IP information
 print(ap.ifconfig())


### PR DESCRIPTION
ap.active is a method (obviously, since its used on the previous line) so it always evaluates to not False. It is NOT a flag indicating an active connection or not. This becomes clear when you try to print(ap.active)